### PR TITLE
Run init in beginning of npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build:client && npm run build:server",
     "check": "npm run type-check && npm run lint:fix && npm run prettier",
     "deploy": "npm run build && devvit upload",
-    "dev": "concurrently -k -p \"[{name}]\" -n \"CLIENT,SERVER,DEVVIT\" -c \"blue,green,magenta\" \"npm run dev:client\" \"npm run dev:server\" \"npm run dev:devvit\"",
+    "dev": "npx devvit@next init && concurrently -k -p \"[{name}]\" -n \"CLIENT,SERVER,DEVVIT\" -c \"blue,green,magenta\" \"npm run dev:client\" \"npm run dev:server\" \"npm run dev:devvit\"",
     "dev:client": "cd src/client && vite build --watch",
     "dev:devvit": "devvit playtest",
     "dev:server": "cd src/server && vite build --watch",


### PR DESCRIPTION
## 💸 TL;DR
Add `devvit init` as step in `npm run dev`. `init` is a no-op if the app is already initialized. This will make `npm run dev` work in Bolt from the get go.
