### PR TITLE
Add dark mode colors

### DIFF
--- a/src/client/game.tsx
+++ b/src/client/game.tsx
@@ -8,19 +8,19 @@ import { useCounter } from './hooks/useCounter';
 export const App = () => {
   const { count, username, loading, increment, decrement } = useCounter();
   return (
-    <div className="flex relative flex-col justify-center items-center min-h-screen gap-4">
+    <div className="flex relative flex-col justify-center items-center min-h-screen gap-4 bg-white dark:bg-gray-900">
       <img
         className="object-contain w-1/2 max-w-[250px] mx-auto"
         src="/snoo.png"
         alt="Snoo"
       />
       <div className="flex flex-col items-center gap-2">
-        <h1 className="text-2xl font-bold text-center text-gray-900 ">
+        <h1 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100">
           {username ? `Hey ${username} 👋` : ''}
         </h1>
-        <p className="text-base text-center text-gray-600 ">
+        <p className="text-base text-center text-gray-600 dark:text-gray-300">
           Edit{' '}
-          <span className="bg-[#e5ebee]  px-1 py-0.5 rounded">
+          <span className="bg-[#e5ebee] dark:bg-gray-700 px-1 py-0.5 rounded">
             src/client/game.tsx
           </span>{' '}
           to get started.
@@ -28,40 +28,40 @@ export const App = () => {
       </div>
       <div className="flex items-center justify-center mt-5">
         <button
-          className="flex items-center justify-center bg-[#d93900] text-white w-14 h-14 text-[2.5em] rounded-full cursor-pointer font-mono leading-none transition-colors"
+          className="flex items-center justify-center bg-[#d93900] dark:bg-orange-600 text-white w-14 h-14 text-[2.5em] rounded-full cursor-pointer font-mono leading-none transition-colors hover:bg-[#c23300] dark:hover:bg-orange-700"
           onClick={decrement}
           disabled={loading}
         >
           -
         </button>
-        <span className="text-[1.8em] font-medium mx-5 min-w-[50px] text-center leading-none text-gray-900">
+        <span className="text-[1.8em] font-medium mx-5 min-w-[50px] text-center leading-none text-gray-900 dark:text-white">
           {loading ? '...' : count}
         </span>
         <button
-          className="flex items-center justify-center bg-[#d93900] text-white w-14 h-14 text-[2.5em] rounded-full cursor-pointer font-mono leading-none transition-colors"
+          className="flex items-center justify-center bg-[#d93900] dark:bg-orange-600 text-white w-14 h-14 text-[2.5em] rounded-full cursor-pointer font-mono leading-none transition-colors hover:bg-[#c23300] dark:hover:bg-orange-700"
           onClick={increment}
           disabled={loading}
         >
           +
         </button>
       </div>
-      <footer className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3 text-[0.8em] text-gray-600">
+      <footer className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3 text-[0.8em] text-gray-600 dark:text-gray-400">
         <button
-          className="cursor-pointer"
+          className="cursor-pointer hover:text-gray-900 dark:hover:text-white transition-colors"
           onClick={() => navigateTo('https://developers.reddit.com/docs')}
         >
           Docs
         </button>
-        <span className="text-gray-300">|</span>
+        <span className="text-gray-300 dark:text-gray-600">|</span>
         <button
-          className="cursor-pointer"
+          className="cursor-pointer hover:text-gray-900 dark:hover:text-white transition-colors"
           onClick={() => navigateTo('https://www.reddit.com/r/Devvit')}
         >
           r/Devvit
         </button>
-        <span className="text-gray-300">|</span>
+        <span className="text-gray-300 dark:text-gray-600">|</span>
         <button
-          className="cursor-pointer"
+          className="cursor-pointer hover:text-gray-900 dark:hover:text-white transition-colors"
           onClick={() => navigateTo('https://discord.com/invite/R7yu2wh9Qz')}
         >
           Discord

--- a/src/client/splash.tsx
+++ b/src/client/splash.tsx
@@ -7,19 +7,19 @@ import { createRoot } from 'react-dom/client';
 
 export const Splash = () => {
   return (
-    <div className="flex relative flex-col justify-center items-center min-h-screen gap-4">
+    <div className="flex relative flex-col justify-center items-center min-h-screen gap-4 bg-white dark:bg-gray-900">
       <img
         className="object-contain w-1/2 max-w-[250px] mx-auto"
         src="/snoo.png"
         alt="Snoo"
       />
       <div className="flex flex-col items-center gap-2">
-        <h1 className="text-2xl font-bold text-center text-gray-900 ">
+        <h1 className="text-2xl font-bold text-center text-gray-900 dark:text-white">
           Hey {context.username ?? 'user'} 👋
         </h1>
-        <p className="text-base text-center text-gray-600 ">
+        <p className="text-base text-center text-gray-600 dark:text-gray-300">
           Edit{' '}
-          <span className="bg-[#e5ebee]  px-1 py-0.5 rounded">
+          <span className="bg-[#e5ebee] dark:bg-gray-700 px-1 py-0.5 rounded">
             src/client/splash.tsx
           </span>{' '}
           to get started.
@@ -27,29 +27,29 @@ export const Splash = () => {
       </div>
       <div className="flex items-center justify-center mt-5">
         <button
-          className="flex items-center justify-center bg-[#d93900] text-white w-auto h-10 rounded-full cursor-pointer transition-colors px-4"
+          className="flex items-center justify-center bg-[#d93900] dark:bg-orange-600 text-white w-auto h-10 rounded-full cursor-pointer transition-colors px-4 hover:bg-[#c23300] dark:hover:bg-orange-700"
           onClick={(e) => requestExpandedMode(e.nativeEvent, 'game')}
         >
           Tap to Start
         </button>
       </div>
-      <footer className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3 text-[0.8em] text-gray-600">
+      <footer className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3 text-[0.8em] text-gray-600 dark:text-gray-400">
         <button
-          className="cursor-pointer"
+          className="cursor-pointer hover:text-gray-900 dark:hover:text-white transition-colors"
           onClick={() => navigateTo('https://developers.reddit.com/docs')}
         >
           Docs
         </button>
-        <span className="text-gray-300">|</span>
+        <span className="text-gray-300 dark:text-gray-600">|</span>
         <button
-          className="cursor-pointer"
+          className="cursor-pointer hover:text-gray-900 dark:hover:text-white transition-colors"
           onClick={() => navigateTo('https://www.reddit.com/r/Devvit')}
         >
           r/Devvit
         </button>
-        <span className="text-gray-300">|</span>
+        <span className="text-gray-300 dark:text-gray-600">|</span>
         <button
-          className="cursor-pointer"
+          className="cursor-pointer hover:text-gray-900 dark:hover:text-white transition-colors"
           onClick={() => navigateTo('https://discord.com/invite/R7yu2wh9Qz')}
         >
           Discord


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
The template didn't have any dark mode colors specified in tailwind, so it was always in light mode regardless of the user's system settings. This also meant that the UI Simulator wasn't working. I thought this was an issue with shreddit setting `colorScheme` manually on the webview dialog and the app not being able to read that when checking the system theme settings, and was thinking we would need to pass isDarkMode in app context. But it seems like specifying dark colors works correctly, both in the base app and in UI simulator mode.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](https://reddit.atlassian.net/browse/DX-9900)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
Tested by uploading the modified template as a new app and confirmed that light and dark mode colors work as expected, and UI Simulator works correctly when user's Reddit theme is in dark/light/or auto.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee


https://github.com/user-attachments/assets/a589b598-be7e-4d07-92e7-e2bbec1d7ed7

