### PR TITLE
[dependabot.yml] Group the devvit dependencies into the same PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/" # Location of your package.json and package-lock.json
     schedule:
-      interval: "weekly"
-      day: "tuesday"
+      interval: "cron"
+      cronjob: "0 17 * * 1,2" # At 5pm on Monday and Tuesday - https://crontab.guru/
+      timezone: "America/New_York"
     open-pull-requests-limit: 10 # Optional: prevents PR spam by limiting active updates
     groups:
       devvit:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
       interval: "weekly"
       day: "tuesday"
     open-pull-requests-limit: 10 # Optional: prevents PR spam by limiting active updates
+    groups:
+      devvit:
+        patterns:
+          - "devvit"
+          - "@devvit/*"


### PR DESCRIPTION
This should help make the version bump upgrades easier, by grouping them all into one PR!

Also changed the job frequency, to run on Monday and Tuesday at 5pm (to catch if we end up doing a late deploy and/or Monday's a holiday).